### PR TITLE
add pixie custom secret support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ const app = new cdk.App();
 blueprints.EksBlueprint.builder()
     .addOns(new blueprints.MetricsServerAddOn)
     .addOns(new blueprints.ClusterAutoScalerAddOn)
-    .addOns(new blueprints.addons.SSMAgentAddOn)
-    .addOns(new blueprints.addons.SecretsStoreAddOn)
+    .addOns(new blueprints.SSMAgentAddOn)
+    .addOns(new blueprints.SecretsStoreAddOn)
     .addOns(new NewRelicAddOn({
-        version: "4.2.0-beta",
+        version: "4.3.1-beta",
         newRelicClusterName: "demo-cluster",
         awsSecretName: "newrelic-pixie-combined", // Secret Name in AWS Secrets Manager
         installPixie: true,
@@ -66,8 +66,8 @@ import { NewRelicAddOn } from '@newrelic/newrelic-eks-blueprints-addon';
 const app = new cdk.App();
 
 blueprints.EksBlueprint.builder()
-    .addOns(new blueprints.MetricsServerAddOn)
-    .addOns(new blueprints.ClusterAutoScalerAddOn)
+    .addOns(new blueprints.addons.MetricsServerAddOn)
+    .addOns(new blueprints.addons.ClusterAutoScalerAddOn)
     .addOns(new blueprints.addons.SSMAgentAddOn)
     .addOns(new blueprints.addons.SecretsStoreAddOn)
     .addOns(new NewRelicAddOn({

--- a/examples/demo-construct/index.ts
+++ b/examples/demo-construct/index.ts
@@ -13,7 +13,7 @@ export default class NewRelicConstruct extends Construct {
         const addOns: Array<blueprints.ClusterAddOn> = [
             new blueprints.addons.SecretsStoreAddOn(),
             new NewRelicAddOn({
-                version: "4.2.0-beta",
+                version: "4.3.1-beta",
                 newRelicClusterName: id,
                 // Uncomment "awsSecretName" after you create your secret in AWS Secrets Manager.
                 // Required: nrLicenseKey
@@ -25,7 +25,7 @@ export default class NewRelicConstruct extends Construct {
                 //     "pixieApiKey": "px-api-XXXX",
                 //     "nrLicenseKey": "XXXXNRAL"
                 // }
-                awsSecretName: "newrelic-pixie-combined",
+                // awsSecretName: "newrelic-pixie-combined",
 
                 // Uncomment "installPixie" and "installPixieIntegration" if installing Pixie.
                 // installPixie: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,7 @@ export class NewRelicAddOn extends blueprints.addons.HelmAddOn {
 
             // Set cluster name, global custom secret name and key
             setPath(values, "global.cluster", props.newRelicClusterName)
-            setPath(values, "global.customSecretName", "pl-deploy-secrets");
+            setPath(values, "global.customSecretName", "newrelic-pixie-secrets");
             setPath(values, "global.customSecretLicenseKey", "licenseKey");
 
             this.installPixie(props, values);
@@ -266,12 +266,13 @@ export class NewRelicAddOn extends blueprints.addons.HelmAddOn {
             setPath(values, "pixie-chart.enabled", "true");
             setPath(values, "pixie-chart.deployKey", props.pixieDeployKey ?? "unused");
             setPath(values, "pixie-chart.clusterName", props.newRelicClusterName);
+            setPath(values, "pixie-chart.customDeployKeySecret", "newrelic-pixie-secrets")
         }
 
         if (props.installPixieIntegration && props.awsSecretName) {
             setPath(values, "newrelic-pixie.enabled", "true");
             // "pl-deploy-secrets" secret name must be hardcoded until Pixie allows custom secret names
-            setPath(values, "newrelic-pixie.customSecretApiKeyName", "pl-deploy-secrets");
+            setPath(values, "newrelic-pixie.customSecretApiKeyName", "newrelic-pixie-secrets");
             setPath(values, "newrelic-pixie.customSecretApiKeyKey", "pixieApiKey");
         } else if (props.installPixieIntegration && props.pixieApiKey) {
             setPath(values, "newrelic-pixie.enabled", "true");
@@ -299,7 +300,7 @@ export class NewRelicAddOn extends blueprints.addons.HelmAddOn {
                 { path: "pixieDeployKey", objectAlias: "pixie-deploy-key" }
             ],
             kubernetesSecret: {
-                secretName: "pl-deploy-secrets",
+                secretName: "newrelic-pixie-secrets",
                 data: [
                     { key: "licenseKey", objectName: "newrelic-license-key"},
                     { key: "pixieApiKey", objectName: "pixie-api-key"},


### PR DESCRIPTION
In previous versions, Pixie did not support the storing the deploy key in a custom secret name so we had to use `pl-deploy-secrets` for all keys, including New Relic keys.  Pixie now supports a custom secret name for the deploy key so all keys will be stored in the `newrelic-pixie-secrets` secret.